### PR TITLE
Update highlights.scm

### DIFF
--- a/after/queries/php/highlights.scm
+++ b/after/queries/php/highlights.scm
@@ -1,4 +1,1 @@
-; extends
 
-(php_tag) @tag
-"?>" @tag


### PR DESCRIPTION
The "Invalid node type "?>" error occurs because the modern Tree-sitter parser for PHP (which was updated when we migrated to the main configuration) no longer uses this node type—it's now usually php_tag or part of the text. You have a great theme that's the only one that fully complies with vs. code. It's better to have one tag not highlighted than to have the entire theme not work. If you remove this, the theme will work on new tree-sitters.